### PR TITLE
Deprecate runsusie() arg p

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -17,7 +17,7 @@ Suggests:
     magrittr,
     rmarkdown
 Title: Colocalisation Tests of Two Genetic Traits
-Version: 5.1.1
+Version: 5.1.2
 Date: 2021-06-08
 Authors@R: c(person("Chris", "Wallace", role=c("aut","cre"),
     email = "cew54@cam.ac.uk"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,6 @@
+# coloc 5.1.2
+* deprecate runsusie() argument p
+
 # coloc 5.1.1
 * update plot_dataset() and sensitivity() to fix bug for very small p values displaying as 0
 

--- a/R/susie.R
+++ b/R/susie.R
@@ -403,13 +403,8 @@ coloc.bf_bf=function(bf1,bf2, p1=1e-4, p2=1e-4, p12=5e-6, overlap.min=0.5,trim_b
 ##' @title Run susie on a single coloc-structured dataset
 ##' @param d coloc dataset, must include LD (signed correlation matrix)
 ##' @param suffix suffix label that will be printed with any error messages
-##' @param p prior probability a snp is causal (equivalent to p1 or p2 in
-##'   coloc.abf). By default, this is set to NULL, upon which we will set a
-##'   small null_weight to pass to susie_rss() (see vignette a06 for details
-##'   why). You can override this by setting p as you would p1 or p2 in a coloc
-##'   function, but note that you may miss some true signals that way. Also note
-##'   that neither of these options correspond to the susie_rss() defaults,
-##'   because our goal here is not fine mapping alone.
+##' @param p \bold{Deprecated} Instead directly set the argument null_weight
+##'   (prior probability of no effect) to pass directly to susie_rss().
 ##' @param trimz used to trim datasets for development purposes
 ##' @param r2.prune sometimes SuSiE can return multiple signals in high LD. if
 ##'   you set r2.prune to a value between 0 and 1, sets with index SNPs with LD
@@ -481,13 +476,10 @@ runsusie=function(d,suffix=1,p=NULL,
     susie_args = susie_args[ setdiff(names(susie_args), "max_iter") ]
   }
 
-  ## if(!("null_weight" %in% names(susie_args))) { # set it ourselves
-  ##   susie_args$null_weight=if(!is.null(p)) {
-  ##                            max(1 - length(d$snp)*p, p)
-  ##                          } else {
-  ##                            susie_args$null_weight=1/(length(d$snp)+1) #max(1 - length(d$snp)*p, p)
-  ##                          }
-  ## }
+  if(!is.null(p)) {
+    warning("Argument p is deprecated and has no effect. Set null_weight instead")
+  }
+
   while(!converged) {
     message("running max iterations: ",maxit)
   ## if(!is.null(s_init)) {

--- a/man/runsusie.Rd
+++ b/man/runsusie.Rd
@@ -21,13 +21,8 @@ runsusie(
 
 \item{suffix}{suffix label that will be printed with any error messages}
 
-\item{p}{prior probability a snp is causal (equivalent to p1 or p2 in
-coloc.abf). By default, this is set to NULL, upon which we will set a
-small null_weight to pass to susie_rss() (see vignette a06 for details
-why). You can override this by setting p as you would p1 or p2 in a coloc
-function, but note that you may miss some true signals that way. Also note
-that neither of these options correspond to the susie_rss() defaults,
-because our goal here is not fine mapping alone.}
+\item{p}{\bold{Deprecated} Instead directly set the argument null_weight
+(prior probability of no effect) to pass directly to susie_rss().}
 
 \item{trimz}{used to trim datasets for development purposes}
 

--- a/tests/testthat/test-susie.R
+++ b/tests/testthat/test-susie.R
@@ -18,3 +18,12 @@ test_that("adding dimnames", {
   expect_equal(colnames(result.null$alpha), c(D1$snp,"null"))
   expect_equal(colnames(result.nonull$alpha), c(D1$snp))
 })
+
+test_that("runsusie argument p is deprecated", {
+  expect_warning(runsusie(D1,p=pi0), "Argument p is deprecated")
+})
+
+test_that("null_weight=0 and null_weight=NULL are equivalent", {
+  # Confirm that upstream susieR behavior hasn't changed
+  expect_equal(runsusie(D1,null_weight=NULL), runsusie(D1,null_weight=0))
+})

--- a/vignettes/a06_SuSiE.Rmd
+++ b/vignettes/a06_SuSiE.Rmd
@@ -77,9 +77,7 @@ if(requireNamespace("susieR",quietly=TRUE)) {
 ```
 
 # Important notes on running SuSiE
-`runsusie()` is a wrapper around `susieR::susie_rss()`.  It sets the null_weight parameter - this must be non-zero or we cannot back calculate Bayes factors needed for coloc - adds some colnames to the returned objects (so that snps can be identified easily) and repeats the calls to `susie_rss()` until convergence is achieved. In particular, the `null_weight` is by default set to an (implausibly) small value of \(\frac{1}{1+nsnps}\).  This ensures that we get a posterior probability for the null hypothesis of no association, so we can calculate Bayes factors when needed, but also, by setting such a low value, allows us to capture weak signals that would not be detected if `null_weight` is large.  For coloc purposes, this is fine, because we will include in the coloc step our real prior for a SNP to be causally associated (and by implication our prior belief that no SNPs are causally associated).  At this stage, weak signals will get weeded out.
-
-You can also pass that per-SNP prior to `runsusie()` by setting the parameter `p` (equivalent to `p1` or `p2` in coloc functions).  But **be aware** either option differs from the default behaviour of `susie_rss()` which is not to specify a prior for the null hypothesis at all.
+`runsusie()` is a wrapper around `susieR::susie_rss()`.  It adds some colnames to the returned objects (so that snps can be identified easily) and repeats the calls to `susie_rss()` until convergence is achieved.
 
 `susie_rss()` has many other options and you should look at them if `runsusie()` is not giving the output you expect.  They can be passed directly through `runsusie()`.
 


### PR DESCRIPTION
This PR is a follow-up to Issue #77

* Removes documentation about `runsusie()` argument `p`
* Sends a warning if a user sets `p` to a non-NULL value (previously this would silently have no effect)
* Adds some tests related to `p` and `null_weight`

I regenerated the pkgdown site locally, but that created a lot of noise, so I didn't include those changes. If you'd like me to rebuild the entire site, please just me let me know.