### PR TITLE
Update sensitivity.R

### DIFF
--- a/R/sensitivity.R
+++ b/R/sensitivity.R
@@ -18,7 +18,7 @@ prior.adjust <- function(summ,newp12,p1=1e-4,p2=1e-4,p12=1e-6) {
 
 
 prior.snp2hyp <- function(nsnp,p12=1e-6,p1=1e-4,p2=1e-4) {
-    if(any(p12<p1*p2) || any(p12 > p1) || any(p12 > p2))
+    if(any(p12 < 10^log10(p1*p2)) || any(p12 > 10^log10(p1)) || any(p12 > 10^log10(p2)))
         return(NULL)
     tmp <- cbind(nsnp * p1,
                  nsnp * p2,
@@ -113,7 +113,7 @@ sensitivity <- function(obj,rule="",
     pass.init <- check(pp)
     message("Results ",if(check(pp)) { "pass" } else { "fail" }, " decision rule ",rule.init)
 
-    testp12 <- 10^seq(log10(p1*p2),log10(min(p1,p1)),length.out=npoints)
+    testp12 <- 10^seq(log10(p1*p2),log10(min(p1,p2)),length.out=npoints)
     testH <- prior.snp2hyp(pp["nsnps"],p12=testp12,p1=p1,p2=p2)
     testpp <- as.data.frame(prior.adjust(summ=pp,newp12=testp12,p1=p1,p2=p2,p12=p12))
     colnames(testpp) <- gsub("(H.)","PP.\\1.abf",colnames(testpp),perl=TRUE)


### PR DESCRIPTION
In the sensitivity function it was written min(p1,p1). I substituted it with min(p1,p2). 
Additionally, with small numbers x is not always equivalent to 10^log10(x), because of this my analysis stopped when testp12 was the argument for prior.snp2hyp(). I think the best solution is changing the 'if' in this function so: (any(p12 < 10^log10(p1*p2)) || any(p12 > 10^log10(p1)) || any(p12 > 10^log10(p2)))