### PR TITLE
Add website to DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,7 @@ VignetteBuilder: knitr
 Roxygen: list(markdown = TRUE)
 RoxygenNote: 7.2.3
 Encoding: UTF-8
-URL: https://github.com/chr1swallace/coloc
+URL: https://github.com/chr1swallace/coloc, https://chr1swallace.github.io/coloc/
 BugReports: https://github.com/chr1swallace/coloc/issues
 Collate:
     'coloc-package.R'


### PR DESCRIPTION
Consider adding it in the About page on the GitHub homepage.
![image](https://github.com/chr1swallace/coloc/assets/52606734/92b127c6-ba6d-45f7-b711-e14ae8e722ae)
