### PR TITLE
Update susie.R to retain dimnames in single-variant edge-case

### DIFF
--- a/R/susie.R
+++ b/R/susie.R
@@ -386,7 +386,7 @@ runsusie=function(d,suffix=1,
     z=d$beta/sqrt(d$varbeta)
   else
     z=d$z
-  LD=d$LD[d$snp,d$snp] # just in case
+  LD=d$LD[d$snp,d$snp, drop = FALSE] # just in case
   names(z)=d$snp
   snp=d$snp
 


### PR DESCRIPTION
Hi! 

Thanks for the great package! I am currently struggling with an edge-case, where the input to `runsusie()` is a data set that contains only a single variant. I would expect the function to simply pass the data through (or similar), but it throws a error, since the dimnames are dropped when sub-setting a matrix to a single row, unless `drop = FALSE` is added to the sub-setting operation:

```r
Error in if (nrow(R) != p) stop(paste0("The dimension of R (", nrow(R),  : 
  argument is of length zero
```

 I am unsure about the consequences of trying to fine-map a single SNP, but if it does not have any downstream consequences, it might be helpful (at least for my workflow) to be able to perform colocalization analysis using `runsusie` and `coloc.susie` with a single SNP.

Kind regards,

Carl

---

Commit message:

Patch edge-case in `runsusie()`

* add `drop = FALSE` to the subsetting of the LD matrix in `runsusie` so dimnames are not dropped in case the LD matrix has only a single row. Otherwise, LD for the single SNP cannot be found, leading to an error